### PR TITLE
Allow event filter based on an existing user

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Keys.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Keys.java
@@ -28,6 +28,7 @@ public enum Keys {
   GERRIT_PORT("gerrit.port", "gerrit-port", 29418),
   GERRIT_FRONT_URL("gerrit.canonicalWebUrl", "gerrit-front-url", ""),
   GERRIT_VERSION("gerrit.version", "gerrit-version", null),
+  SECURITY_AUTHUSER("security.authUser", null, null),
   MONITOR_INTERVAL("monitor.interval", null, 15000),
   MONITOR_FAILURECOUNT("monitor.failureCount", null, 15);
 

--- a/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Module.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Module.java
@@ -18,14 +18,26 @@ import com.google.gerrit.common.ChangeListener;
 import com.google.gerrit.extensions.events.LifecycleListener;
 import com.google.gerrit.extensions.registration.DynamicSet;
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
 
 class Module extends AbstractModule {
+
+  private final Properties properties;
+
+  @Inject
+  public Module(Properties properties) {
+    this.properties = properties;
+  }
+
   @Override
   protected void configure() {
     bind(AMQPSession.class);
     bind(Properties.class);
     bind(RabbitMQManager.class);
-    DynamicSet.bind(binder(), ChangeListener.class).to(RabbitMQManager.class);
+    if (!properties.hasAuthUser()) {
+      // No authUser to filter events against. Register an unrestricted ChangeListener
+      DynamicSet.bind(binder(), ChangeListener.class).to(RabbitMQManager.class);
+    }
     DynamicSet.bind(binder(), LifecycleListener.class).to(RabbitMQManager.class);
   }
 }

--- a/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Properties.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Properties.java
@@ -14,12 +14,10 @@
 
 package com.googlesource.gerrit.plugins.rabbitmq;
 
-import com.google.gerrit.common.Version;
-import com.google.gerrit.server.config.GerritServerConfig;
-import com.google.gerrit.server.config.SitePaths;
-import com.google.inject.Inject;
-
-import com.rabbitmq.client.AMQP;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.lang.StringUtils;
@@ -30,10 +28,11 @@ import org.eclipse.jgit.util.FS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import com.google.gerrit.common.Version;
+import com.google.gerrit.server.config.GerritServerConfig;
+import com.google.gerrit.server.config.SitePaths;
+import com.google.inject.Inject;
+import com.rabbitmq.client.AMQP;
 
 public class Properties {
 
@@ -98,6 +97,15 @@ public class Properties {
 
   public String getGerritFrontUrl() {
     return StringUtils.stripToEmpty(config.getString(Keys.GERRIT_FRONT_URL.section, null, Keys.GERRIT_FRONT_URL.name));
+  }
+
+  public boolean hasAuthUser() {
+    return !getAuthUser().isEmpty();
+  }
+
+  public String getAuthUser() {
+    return StringUtils.stripToEmpty(pluginConfig.getString(
+        Keys.SECURITY_AUTHUSER.section, null, Keys.SECURITY_AUTHUSER.name));
   }
 
   public String getGerritVersion() {


### PR DESCRIPTION
If you specify the following in rabbitmq.config:

[security]
    authUser = jenkins_verifier

It will filter out all events that is not visible for
that Gerrit-user. In this case "jenkins_verifier".

Change-Id: I28411ca3795badcbf9ff5fe95039e8f84c590055
