### PR TITLE
Add @Singleton to Properties class

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Properties.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Properties.java
@@ -18,7 +18,7 @@ import com.google.gerrit.common.Version;
 import com.google.gerrit.server.config.GerritServerConfig;
 import com.google.gerrit.server.config.SitePaths;
 import com.google.inject.Inject;
-
+import com.google.inject.Singleton;
 import com.rabbitmq.client.AMQP;
 
 import org.apache.commons.codec.CharEncoding;
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+@Singleton
 public class Properties {
 
   // TODO: Value will be replaced to "gerrit.event".
@@ -112,7 +113,7 @@ public class Properties {
     return interval;
   }
 
-  public AMQP.BasicProperties getBasicProperties() {
+  public synchronized AMQP.BasicProperties getBasicProperties() {
     if (properties == null) {
       Map<String, Object> headers = new HashMap<String, Object>();
       headers.put(Keys.GERRIT_NAME.key, getString(Keys.GERRIT_NAME));


### PR DESCRIPTION
Prevent loading the plugin configuration more than once. Before this
change, configuration file was loaded every time the Properties class
is injected into another class. Now the same instance in injected into
any class that depends on it so the configurations file in no longer
loaded multiple times.

Properties can be concurrently accessed so synchronize the
getBasicProperties method to prevent concurrent lazy loading of the
properties map.
