### PR TITLE
Update gradle config to support local Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ shadow {
 }
 
 repositories {
+  mavenLocal()
   mavenCentral()
   maven {
     name = "Gerrit API repository"


### PR DESCRIPTION
When building the plugin with a locally built SNAPSHOT version of
the plugin API, it is neccessary to consume the API artifact from
the local Maven repository.

Add the necessary setting in the gradle configuration to make this
possible.

Change-Id: Ib6618572e69e1139baf8ba85e921e100045dca49