### PR TITLE
Build with API version 2.11-SNAPSHOT and fix build errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 apiType=plugin
-apiVersion=2.10
+apiVersion=2.11-SNAPSHOT

--- a/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Module.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/rabbitmq/Module.java
@@ -14,7 +14,7 @@
 
 package com.googlesource.gerrit.plugins.rabbitmq;
 
-import com.google.gerrit.common.ChangeListener;
+import com.google.gerrit.common.EventListener;
 import com.google.gerrit.extensions.events.LifecycleListener;
 import com.google.gerrit.extensions.registration.DynamicSet;
 import com.google.inject.AbstractModule;
@@ -36,7 +36,7 @@ class Module extends AbstractModule {
     bind(RabbitMQManager.class);
     if (!properties.hasListenAs()) {
       // No listenAs to filter events against. Register an unrestricted ChangeListener
-      DynamicSet.bind(binder(), ChangeListener.class).to(RabbitMQManager.class);
+      DynamicSet.bind(binder(), EventListener.class).to(RabbitMQManager.class);
     }
     DynamicSet.bind(binder(), LifecycleListener.class).to(RabbitMQManager.class);
   }


### PR DESCRIPTION
The events API is changed in gerrit version 2.11:

- ChangeListener was replaced by EventListener

- ChangeHooks was replaced by EventSource

Update the code to use the new interfaces.

Change-Id: I8c30a90743dc62146586f81ced51b7de4741b6db